### PR TITLE
Track outbound links on /tools page

### DIFF
--- a/pages/activities.jsx
+++ b/pages/activities.jsx
@@ -3,13 +3,9 @@ var ImageTag = require('../components/imagetag.jsx');
 var Illustration = require('../components/illustration.jsx');
 var IconLinks = require('../components/icon-links.jsx');
 var IconLink = require('../components/icon-link.jsx');
-var Router = require('react-router');
-var Link = Router.Link;
-
 var HeroUnit = require('../components/hero-unit.jsx');
-
-var ga = require('react-ga');
-var OutboundLink = ga.OutboundLink;
+var Link = require('react-router').Link;
+var OutboundLink = require('react-ga').OutboundLink;
 
 /* Displays an activity kit, with:
    image, title, difficulty, list of authors, and description
@@ -87,7 +83,7 @@ var ActivityKit = React.createClass({
         src2x={this.props.src2x}
         alt={this.props.title}
         link={this.props.link}
-        externalLink>
+        externalLink={true}>
           <div className="activity-kit-content">
             <h3><OutboundLink to={this.props.link} eventLabel={this.props.link}>{this.props.title}</OutboundLink></h3>
             <div>

--- a/pages/tools.jsx
+++ b/pages/tools.jsx
@@ -1,8 +1,6 @@
 var React = require('react');
-var Router = require('react-router');
-var Link = Router.Link;
-var ga = require('react-ga');
-var OutboundLink = ga.OutboundLink;
+var Link = require('react-router').Link;
+var OutboundLink = require('react-ga').OutboundLink;
 var Illustration = require('../components/illustration.jsx');
 var IconLinks = require('../components/icon-links.jsx');
 var IconLink = require('../components/icon-link.jsx');
@@ -55,7 +53,7 @@ var ToolsColumn = React.createClass({
           src2x={this.props.src2x}
           alt=""
           className="vertical-layout"
-          externalLink>
+          externalLink={true}>
           <h2><OutboundLink to={this.props.link} eventLabel={this.props.link}>{this.props.name}</OutboundLink></h2>
           <p>{this.props.description}</p>
         </Illustration>

--- a/pages/tools.jsx
+++ b/pages/tools.jsx
@@ -1,7 +1,9 @@
 var React = require('react');
-var Illustration = require('../components/illustration.jsx');
 var Router = require('react-router');
 var Link = Router.Link;
+var ga = require('react-ga');
+var OutboundLink = ga.OutboundLink;
+var Illustration = require('../components/illustration.jsx');
 var IconLinks = require('../components/icon-links.jsx');
 var IconLink = require('../components/icon-link.jsx');
 var config = require('../lib/config');
@@ -52,8 +54,9 @@ var ToolsColumn = React.createClass({
           src1x={this.props.src1x}
           src2x={this.props.src2x}
           alt=""
-          className="vertical-layout">
-          <h2><a href={this.props.link}>{this.props.name}</a></h2>
+          className="vertical-layout"
+          externalLink>
+          <h2><OutboundLink to={this.props.link} eventLabel={this.props.link}>{this.props.name}</OutboundLink></h2>
           <p>{this.props.description}</p>
         </Illustration>
         {sampleActivity}


### PR DESCRIPTION
This fixes #1196 and uses [`<OutboundLink>` component](https://github.com/mozilla/react-ga/blob/fa681ffafdb094b0e05a1cf1e80d695f84942a6b/src/components/OutboundLink.js) on Adam's react-ga