### PR TITLE
Tidy up colorizer mixins

### DIFF
--- a/components/map.jsx
+++ b/components/map.jsx
@@ -59,7 +59,7 @@ var MarkerPopup = React.createClass({
   },
   render: function() {
     return (
-      <ul className="popup-clubs-list">
+      <ul className="popup-clubs-list colored-list">
         {this.props.clubs.map(function(club, i) {
           return React.createElement(MarkerPopupClub, _.extend({
             key: i,

--- a/less/components/map.less
+++ b/less/components/map.less
@@ -23,7 +23,6 @@
 }
 
 .popup-clubs-list {
-  .listItemBorderColorizer(@orangeSidebarColor);
   padding-left: 0;
   margin-bottom: 0;
   list-style-type: none;

--- a/less/components/sidebar.less
+++ b/less/components/sidebar.less
@@ -14,18 +14,21 @@ html.no-js .sidebar {
 }
 
 .page {
+  &.about-page {
+    .pageColorizer(@blueSidebarColor);
+  }
   &.events,
   &.event-resources {
-    .sidebarColorizer(@darkBlueSidebarColor);
+    .pageColorizer(@darkBlueSidebarColor);
   }
   &.teach-like-mozilla,
   &.tools-page,
   &.web-literacy {
-    .sidebarColorizer(@greenSidebarColor);
+    .pageColorizer(@greenSidebarColor);
   }
   &.clubs,
   &.clubs-list-page {
-    .sidebarColorizer(@orangeSidebarColor);
+    .pageColorizer(@orangeSidebarColor);
   }
   &.teaching-materials,
   &.web-lit-basics,
@@ -35,7 +38,7 @@ html.no-js .sidebar {
   &.madewithcode-poster,
   &.maker-party-2015,
   &.private-eye {
-    .sidebarColorizer(@pinkSidebarColor);
+    .pageColorizer(@pinkSidebarColor);
   }
 
   &.teach-like-mozilla .teach,

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -1,28 +1,26 @@
-.listItemBorderColorizer(@borderColor:@bodyTextColor) {
-  li {
-    border-bottom: .1rem solid lighten(@borderColor, 30%);
-    padding: 1.2rem 0;
-    &:first-child {
-      border-top: .1rem solid lighten(@borderColor, 30%);
-    }
-  }
-}
-
-.sidebarColorizer(@sidebarColor) {
+.pageColorizer(@pageColor:@blueSidebarColor) {
+  // apply color to sidebar
   a.skip-to-content:focus {
-    background-color: @sidebarColor;
+    background-color: @pageColor;
   }
-
   .sidebar {
-    background-color: @sidebarColor;
+    background-color: @pageColor;
     .sidebar-menu a {
       &:hover, &:focus, &.active {
-        background-color: darken(@sidebarColor, 5%);
+        background-color: darken(@pageColor, 5%);
       }
     }
-
     .sidebar-menu a .glyphicon {
-      color: lighten(@sidebarColor, 15%);
+      color: lighten(@pageColor, 15%);
+    }
+  }
+  // apply border color to list
+  .colored-list {
+    li {
+      padding: 1.2rem 0;
+      &:not(:first-child) {
+        border-top: .1rem solid lighten(@pageColor, 30%);
+      }
     }
   }
 }

--- a/less/pages/about.less
+++ b/less/pages/about.less
@@ -1,7 +1,4 @@
 .about-page {
-  .list-with-illust {
-    .listItemBorderColorizer(@blueSidebarColor)
-  }
   .our-goal {
     max-width: 80rem;
     margin: 0 auto;

--- a/less/pages/clubs-list.less
+++ b/less/pages/clubs-list.less
@@ -10,9 +10,6 @@
       margin-top: 4rem;
     }
   }
-  .clubs-list {
-    .listItemBorderColorizer(@orangeSidebarColor);
-  }
 }
 
 .club-location {

--- a/less/pages/teach-like-mozilla.less
+++ b/less/pages/teach-like-mozilla.less
@@ -16,8 +16,5 @@
   }
   .list-with-illust {
     margin-top: 4rem;
-    ul {
-      .listItemBorderColorizer(@greenSidebarColor);
-    }
   }
 }

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -32,7 +32,7 @@ var OurFocus = React.createClass({
           <Illustration width={199} height={199}
           src1x="/img/pages/about/about-illustration.svg"
           alt="A graphic showing an illustration of a person, a book, some gears, a map pin, and a square acedemic cap">
-            <ul>
+            <ul className="colored-list">
               <li>Learn and deepen your 21st Century digital skills, and get better at teaching them to others.</li>
               <li>Contribute to real-world products and projects that are open, participatory and networked.</li>
               <li>Access free resources like event planning guides and step-by-step teaching activities, or share your own resources to receive feedback from peers.</li>

--- a/pages/clubs-list.jsx
+++ b/pages/clubs-list.jsx
@@ -69,7 +69,7 @@ var ClubList = React.createClass({
     var colClass = 'col-xs-' + (this.GRID_COLUMNS_PER_ROW / this.COLUMNS);
     return (
       <div className={colClass} key={key}>
-        <ul className="clubs-list list-unstyled">
+        <ul className="list-unstyled colored-list">
           {clubs.map(function(club, i) {
             return  <ClubListItem key={i} club={club}
                                   username={this.props.username}

--- a/pages/teach-like-mozilla.jsx
+++ b/pages/teach-like-mozilla.jsx
@@ -28,7 +28,7 @@ var TeachLikeMozillaPage = React.createClass({
               width={242} height={175}
               src1x="/img/pages/teach-like-mozilla/svg/icon-teach-like-mozilla.svg"
               alt="icon teach like mozilla">
-                <ul>
+                <ul className="colored-list">
                   <li>
                     We teach web literacy, which encompasses the mechanics,
                     culture and citizenship of the web.


### PR DESCRIPTION
Fixed #1002 

- [x] Clean up colorizer related mixins by merging them into one mixin called `.pageColorizer()`
- [x] Borders for `.colored-list` should only appear in between the list items `<li>`