### PR TITLE
put link wrapping in the right place

### DIFF
--- a/components/illustration.jsx
+++ b/components/illustration.jsx
@@ -1,7 +1,5 @@
 var React = require('react');
 var ImageTag = require('./imagetag.jsx');
-var ga = require('react-ga');
-var OutboundLink = ga.OutboundLink;
 
 var Illustration = React.createClass({
   propTypes: {
@@ -21,25 +19,13 @@ var Illustration = React.createClass({
                           src1x={this.props.src1x}
                           src2x={this.props.src2x}
                           alt={this.props.alt}
-                          caption={this.props.caption} />;
-
-    var link = image;
-    if (this.props.link) {
-      if (this.props.externalLink) {
-        link = <OutboundLink to={this.props.link} eventLabel={this.props.link}>{ image }</OutboundLink>
-      } else {
-        link = <a href={this.props.link}>{ image }</a>;
-      }
-    }
-
-    var imageContainer = <div className="image-container">{link}</div>;
-
-    var contentContainer = <div className="content-container">{this.props.children}</div>;
-
+                          caption={this.props.caption}
+                          link={this.props.link}
+                          externalLink={this.props.externalLink}/>;
     return (
       <div className={classes}>
-        {imageContainer}
-        {contentContainer}
+        <div className="image-container">{image}</div>
+        <div className="content-container">{this.props.children}</div>
       </div>
     );
   }

--- a/components/imagetag.jsx
+++ b/components/imagetag.jsx
@@ -1,4 +1,6 @@
 var React = require('react');
+var ga = require('react-ga');
+var OutboundLink = ga.OutboundLink;
 
 var ImageTag = React.createClass({
   propTypes: {
@@ -8,19 +10,32 @@ var ImageTag = React.createClass({
     width: React.PropTypes.number,
     height: React.PropTypes.number,
     className: React.PropTypes.string,
+    link: React.PropTypes.string,
+    externalLink: React.PropTypes.bool,
     caption: React.PropTypes.object
   },
 
   render: function () {
+    var image = <img alt={this.props.alt}
+                     width={this.props.width}
+                     height={this.props.height}
+                     src={this.props.src1x}
+                     srcSet={this.props.src2x ? this.props.src2x + ' 2x' : null} />;
+
+    var content = image;
+    if (this.props.link) {
+      if (this.props.externalLink) {
+        content = <OutboundLink to={this.props.link} eventLabel={this.props.link}>{ image }</OutboundLink>
+      } else {
+        content = <a href={this.props.link}>{ image }</a>;
+      }
+    }
+
     return (
-        <figure className={this.props.className}>
-          <img alt={this.props.alt}
-               width={this.props.width}
-               height={this.props.height}
-               src={this.props.src1x}
-               srcSet={this.props.src2x ? this.props.src2x + ' 2x' : null} />
-          { !!this.props.caption ? <figcaption>{ this.props.caption }</figcaption> : null }
-        </figure>
+      <figure className={this.props.className}>
+        { content }
+        { !!this.props.caption ? <figcaption>{ this.props.caption }</figcaption> : null }
+      </figure>
     );
   }
 });


### PR DESCRIPTION
fixes https://github.com/mozilla/teach.mozilla.org/issues/1401

This moves the illustration image link wrapping into the ImageTag component instead of the Illustration component, so that captions don't get wrapped by links.