### PR TITLE
removed lwip conversion entirely

### DIFF
--- a/lib/build/gulp-image-converter.js
+++ b/lib/build/gulp-image-converter.js
@@ -2,40 +2,13 @@ var path = require('path');
 var _ = require('underscore');
 var Minimatch = require('minimatch').Minimatch;
 var through = require('through2');
-var lwip = require('lwip');
 var gutil = require('gulp-util');
 var SVGO = require('svgo');
 var File = require('vinyl');
 
 function convert(options, file, cb) {
-  var format = path.extname(file.path).slice(1);
-  var targetFormat = options.format || format;
-
-  lwip.open(file.contents, format, function(err, image) {
-    if (err) {
-      return cb(err);
-    }
-
-    image.toBuffer(
-      targetFormat,
-      options.formatParams || {},
-      function(err, buffer) {
-        if (err) {
-          return cb(err);
-        }
-        file = new File(file);
-        file.extname = '.' + targetFormat;
-        file.contents = buffer;
-
-        gutil.log(
-          'converted ' +
-          gutil.colors.cyan(file.relative) + ' (' +
-          (Math.floor(buffer.length / 1024)) + 'k)'
-        );
-        cb(null, file);
-      }
-    );
-  });
+  // removed lwip conversion
+  cb(null, file);
 }
 
 function optimizeSvg(svgo, file, cb) {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,9 @@
   "bugs": {
     "url": "https://github.com/mozilla/teach.mozilla.org/issues"
   },
-
-  "engines" : {
-    "node" : ">=0.12.0"
+  "engines": {
+    "node": ">=0.12.0"
   },
-
   "scripts": {
     "app": "gulp app",
     "build": "gulp",
@@ -37,7 +35,6 @@
     "test:mocha": "mocha test/*.test.js",
     "travis-after-success": "gulp travis-after-success"
   },
-
   "dependencies": {
     "babel-core": "^6.3.21",
     "bootstrap": "^3.3.4",
@@ -67,7 +64,6 @@
     "json-loader": "^0.5.1",
     "jsx-loader": "^0.13.2",
     "leaflet.markercluster": "^0.4.0",
-    "lwip": "0.0.8",
     "mapbox.js": "^2.1.5",
     "merge-stream": "^1.0.0",
     "minimatch": "^3.0.0",
@@ -98,10 +94,10 @@
     "webpack-stream": "^3.1.0"
   },
   "devDependencies": {
-    "mocha-phantomjs": "^4.0.1",
-    "simplecrawler": "^0.5.2",
-    "supertest": "^1.0.1",
     "marked": "^0.3.3",
-    "open": "0.0.5"
+    "mocha-phantomjs": "^4.0.1",
+    "open": "0.0.5",
+    "simplecrawler": "^0.5.2",
+    "supertest": "^1.0.1"
   }
 }


### PR DESCRIPTION
fixes https://github.com/mozilla/teach.mozilla.org/issues/1565 by simply no longer doing the lwip conversion step - I don't see any missing images, but if there are, we should just put the images we need where we need them.