### PR TITLE
April 1: Curriculum workshop page & archived workshop.

### DIFF
--- a/less/pages/curriculum-workshop.less
+++ b/less/pages/curriculum-workshop.less
@@ -32,18 +32,18 @@
   }
 
   .callout-box {
-    background: #e3f7f7;
+    background: @upcoming-workshop-bg;
     position: relative;
     margin: 50px 0 55px 0;
     padding: 40px 30px 30px 30px;
     position: relative;
 
     * {
-      color: #0c9692;
+      color: @upcoming-workshop-text;
     }
 
     h2 {
-      background: #0c9692;
+      background: @upcoming-workshop-text;
       text-transform: uppercase;
       position: absolute;
       top: -19px;
@@ -53,6 +53,18 @@
       color: white;
       font-size: 16px;
       margin: 0;
+    }
+
+    &.past-workshop {
+      background: @past-workshop-bg;
+      * {
+        color: @past-workshop-text;
+      }
+
+      h2 {
+        background: @past-workshop-text;
+        color: @past-workshop-bg;
+      }
     }
 
     .date {
@@ -95,7 +107,7 @@
     margin-left: 12px;
   }
 
-  .upcoming-workshops {
+  .upcoming-workshops, .past-workshops {
     padding: 0;
     list-style-type: none;
 
@@ -103,6 +115,14 @@
       font-size: 1.8rem;
       margin: 0;
       padding: 0;
+    }
+
+    .watch-archive {
+      margin-top: 15px;
+
+      a {
+        font-weight: bold;
+      }
     }
 
     h2 {

--- a/less/variables.less
+++ b/less/variables.less
@@ -48,3 +48,9 @@
 
 // Images
 @image-border-radius: .4rem;
+
+// Workshop Callout
+@upcoming-workshop-bg: #E3F7F7;
+@upcoming-workshop-text: #0C9692;
+@past-workshop-bg: #EFEFEF;
+@past-workshop-text: #333333;

--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -29,6 +29,7 @@ var pages = {
   'clubs/list': require('../pages/clubs-list.jsx'),
   'community': require('../pages/community.jsx'),
   'community/curriculum-workshop': require('../pages/curriculum-workshop.jsx'),
+  'community/curriculum-workshop/march-8-2016': require('../pages/curriculum-workshop-march-8-2016.jsx'),
   'community/community-call': require('../pages/community-call.jsx'),
   'events': require('../pages/events.jsx'),
   'events/resources': require('../pages/event-resources.jsx'),
@@ -90,8 +91,8 @@ var redirectElements = Object.keys(redirects).map(function(path) {
 
 // routes below are listed alphabetically by their path
 // ---
-// Since WordPress page slug is arbitrary, <Route path=":wpSlug"> is added last. 
-// This is basically a catch-all pattern that allows us to grab requested path and pass it 
+// Since WordPress page slug is arbitrary, <Route path=":wpSlug"> is added last.
+// This is basically a catch-all pattern that allows us to grab requested path and pass it
 // as the WP page slug in a WP API call. If WP sends back 200, we display the content.
 // Else error message will be shown on the page. Note that the API call is made on client side.
 // [NOTE] add <Route path=":wpSlug" component={require('../pages/wp-content.jsx')}/> back

--- a/pages/curriculum-workshop-march-8-2016.jsx
+++ b/pages/curriculum-workshop-march-8-2016.jsx
@@ -1,0 +1,83 @@
+var React = require('react');
+var HeroUnit = require('../components/hero-unit.jsx');
+// use this LinkAnchorSwap component for hyperlinks
+var LinkAnchorSwap = require('../components/link-anchor-swap.jsx');
+var Illustration = require('../components/illustration.jsx');
+
+var CurriculumWorkshop = React.createClass({
+  statics: {
+    pageClassName: 'curriculum-workshop'
+  },
+  render: function () {
+    return (
+        <div className="inner-container call-container">
+          <section className="intro intro-after-banner">
+           <Illustration
+             height={175} width={175}
+             src1x="/img/pages/community/svg/icon-circle-community.svg"
+             alt="icon toolkit">
+               <h1>Mozilla Curriculum Workshop</h1>
+               <h2>Join us on the second Tuesday of each month at 8 PM ET!</h2>
+           </Illustration>
+          </section>
+
+          <p>
+          Co-hosts Amira Dhalla and Chad Sansing, along with producer Paul Oh, help participants answer the question, <em>"How can I use the web to teach and learn what’s important to me?"</em> Join us as we prototype teaching and learning materials live on-air and think out-loud through the curriculum design process.
+          </p>
+
+          <section className="callout-box past-workshop">
+            <h2>Past Workshop</h2>
+            <p className="date">March 8th - 5 PM PT, 8 PM ET, 10 PM BRT</p>
+            <h1>International Women's Day</h1>
+            <p className="description">
+              With Ingrid Dahl, Claire Shorall, Kim Wilkens, and friends.
+            </p>
+          </section>
+
+          <p>
+            On our inaugural, International Women’s Day episode, Ingrid Dahl, Claire Shorall, Kim Wilkens and friends prototype teaching and learning materials addressing women’s issues, rights, and accomplishments. Viewers can ask questions and share ideas and prototypes of their own through the embedded agenda and chat.
+          </p>
+
+          <p>
+            You can also join the discussion on <a href="https://discourse.webmaker.org/c/mozilla-curriculum-workshop">our community forum</a> or <a href="https://github.com/MozillaFoundation/curriculum-workshop">GitHub</a>.
+          </p>
+
+          <h3>Workshop Video Stream</h3>
+
+          <div className="video-wrapper">
+            <iframe className="workshop-video" width="560" height="315" src="//www.youtube.com/embed/WqLgWloYvHk" frameBorder="0" allowFullScreen></iframe>
+          </div>
+
+          <h4>
+            Open Agenda
+            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop">
+            </a>
+          </h4>
+
+          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop"></iframe>
+
+          <h2>Upcoming Workshops</h2>
+
+          <ul className="upcoming-workshops">
+            <li>
+              <p className="date">Tuesday, April 12 - 5 PM PT, 8 PM ET, 9 PM BRT</p>
+              <h2>Internet of Things</h2>
+              <p>
+                Consider how the Internet of Things might impact our lives and learning and prototype resources to teach about the ways wearables and household items connect to the web.
+              </p>
+            </li>
+            <li>
+              <p className="date">Tuesday, May 10 -  5 PM PT, 8 PM ET, 9 PM BRT</p>
+              <h2>Letters to the Next President</h2>
+              <p>
+                Take a look at the National Writing Project’s Letters to the Next President (#2nextprez) campaign, remix suggested activities from campaign partners Hypothes.is and Mozilla, and prototype new pathways for youth civic engagement online.
+              </p>
+            </li>
+          </ul>
+
+        </div>
+    );
+  }
+});
+
+module.exports = CurriculumWorkshop;

--- a/pages/curriculum-workshop.jsx
+++ b/pages/curriculum-workshop.jsx
@@ -27,45 +27,38 @@ var CurriculumWorkshop = React.createClass({
 
           <section className="callout-box">
             <h2>Upcoming Workshop</h2>
-            <p className="date">March 8th - 5 PM PT, 8 PM ET, 10 PM BRT</p>
-            <h1>International Women's Day</h1>
+            <p className="date">April 12th - 5 PM PT, 8 PM ET, 9 PM BRT</p>
+            <h1>Physical Computing</h1>
             <p className="description">
-              With Ingrid Dahl, Claire Shorall, Kim Wilkens, and friends.
+              With Jeremy Boggs, Natalie Freed, Andre Garzia, and Jie Qi
             </p>
           </section>
 
           <p>
-            On our inaugural, International Women’s Day episode, Ingrid Dahl, Claire Shorall, Kim Wilkens and friends prototype teaching and learning materials addressing women’s issues, rights, and accomplishments. Viewers can ask questions and share ideas and prototypes of their own through the embedded agenda and chat.
+            On our April episode of the Mozilla Curriculum Workshop, <LinkAnchorSwap to="http://scholarslab.org/people/jeremy-boggs/">Jeremy Boggs</LinkAnchorSwap>, <LinkAnchorSwap to="http://www.nataliefreed.com">Natalie Freed</LinkAnchorSwap>, <LinkAnchorSwap to="http://andregarzia.com/pages/en/blog/">Andre Garzia</LinkAnchorSwap>, and <LinkAnchorSwap to="http://technolojie.com/">Jie Qi</LinkAnchorSwap> will help us understand physical computing as a gateway into the Internet of Things (IoT), the network of connected devices embedded in everyday objects. An in-depth episode on IoT will follow this summer. Viewers can add to the discussion and help us prototype web-native teaching and learning materials about physical computing by participating in our etherpad and chat.
           </p>
 
           <p>
-            You can also join the discussion on <a href="https://discourse.webmaker.org/c/mozilla-curriculum-workshop">our community forum</a> or <a href="https://github.com/MozillaFoundation/curriculum-workshop">GitHub</a>.
+            You can also join the discussion on <LinkAnchorSwap to="https://discourse.webmaker.org/c/mozilla-curriculum-workshop">our community forum</LinkAnchorSwap> or <LinkAnchorSwap to="https://github.com/MozillaFoundation/curriculum-workshop">GitHub</LinkAnchorSwap>.
           </p>
 
           <h3>Workshop Video Stream</h3>
 
           <div className="video-wrapper">
-            <iframe className="workshop-video" width="560" height="315" src="//www.youtube.com/embed/WqLgWloYvHk" frameBorder="0" allowFullScreen></iframe>
+            <iframe width="560" height="315" src="//www.youtube.com/embed/XjyMkGPP3R0" frameborder="0" allowfullscreen></iframe>
           </div>
 
           <h4>
             Open Agenda
-            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop">
+            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-april-12-2016">
             </a>
           </h4>
 
-          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop"></iframe>
+          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-april-12-2016"></iframe>
 
           <h2>Upcoming Workshops</h2>
 
           <ul className="upcoming-workshops">
-            <li>
-              <p className="date">Tuesday, April 12 - 5 PM PT, 8 PM ET, 9 PM BRT</p>
-              <h2>Internet of Things</h2>
-              <p>
-                Consider how the Internet of Things might impact our lives and learning and prototype resources to teach about the ways wearables and household items connect to the web.
-              </p>
-            </li>
             <li>
               <p className="date">Tuesday, May 10 -  5 PM PT, 8 PM ET, 9 PM BRT</p>
               <h2>Letters to the Next President</h2>
@@ -75,6 +68,20 @@ var CurriculumWorkshop = React.createClass({
             </li>
           </ul>
 
+          <h2>Past Workshops</h2>
+
+          <ul className="past-workshops">
+            <li>
+              <p className="date">March 8th, 2016</p>
+              <h2>International Women's Day</h2>
+              <p>
+                On our inaugural, International Women’s Day episode, Ingrid Dahl, Claire Shorall, Kim Wilkens and friends prototype teaching and learning materials addressing women’s issues, rights, and accomplishments. Viewers can ask questions and share ideas and prototypes of their own through the embedded agenda and chat.
+              </p>
+              <p className="watch-archive">
+                <LinkAnchorSwap to="/community/curriculum-workshop/march-8-2016/">Watch the Replay</LinkAnchorSwap>
+              </p>
+            </li>
+          </ul>
         </div>
     );
   }


### PR DESCRIPTION
**Changes**
* Changed the content of the curriculum workshop page to match what's in [this doc](https://docs.google.com/document/d/1ZocSExoh4rfecOjKdfD5ceodoJaRQ6nh0f4YT6RpfwA/edit#).
* Created a separate page for the last workshop to occur and linked it from the main curriculum workshop page

@mmmavis R? 

Once it's on staging, we will get @chadsansing to review.

Fixes https://github.com/mozilla/wp-calypso/issues/36