### PR TITLE
scroll to top for internal page nav links

### DIFF
--- a/components/link-anchor-swap.jsx
+++ b/components/link-anchor-swap.jsx
@@ -17,8 +17,13 @@ var LinkAnchorSwap = React.createClass({
     var linkedContent = this.props.children || this.props.name;
     return (
       ifExternalLink ?  <OutboundLink eventLabel={link} {...this.props}>{linkedContent}</OutboundLink> :
-                        <Link {...this.props}>{linkedContent}</Link>
+                        <Link {...this.props} onClick={this.scrollToTop}>{linkedContent}</Link>
     );
+  },
+  scrollToTop: function() {
+    if (typeof window !== "undefined" && window.scrollTo) {
+      window.scrollTo(0,0);
+    }
   }
 });
 


### PR DESCRIPTION
fixes https://github.com/mozilla/teach.mozilla.org/issues/1812 by giving the link-anchor-swap an onClick handler that calls `window.scrollTo(0,0)`, so that page navigation also makes sure to load the new page with the scrollbar all the way at the top of the new content