### PR TITLE
adding May curriculum workshop details and updating archives

### DIFF
--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -31,6 +31,7 @@ var pages = {
   'community': require('../pages/community.jsx'),
   'community/curriculum-workshop': require('../pages/curriculum-workshop.jsx'),
   'community/curriculum-workshop/march-8-2016': require('../pages/curriculum-workshop-march-8-2016.jsx'),
+  'community/curriculum-workshop/april-12-2016': require('../pages/curriculum-workshop-april-12-2016.jsx'),
   'community/community-call': require('../pages/community-call.jsx'),
   'community/community-call/march-23-2016': require('../pages/community-call-march-23.jsx'),
   'community/community-call/april-20-2016': require('../pages/community-call-april-20.jsx'),

--- a/pages/community-call-march-23.jsx
+++ b/pages/community-call-march-23.jsx
@@ -57,7 +57,6 @@ var CommunityCallPage = React.createClass({
 
           <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/MozTeachCC"></iframe>
 
-          
         </div>
     );
   }

--- a/pages/curriculum-workshop-april-12-2016.jsx
+++ b/pages/curriculum-workshop-april-12-2016.jsx
@@ -28,34 +28,36 @@ var CurriculumWorkshop = React.createClass({
 
           <section className="callout-box past-workshop">
             <h2>Past Workshop</h2>
-            <p className="date">March 8th - 5 PM PT, 8 PM ET, 10 PM BRT</p>
-            <h1>International Women's Day</h1>
+            <p className="date">April 12th - 5 PM PT, 8 PM ET, 10 PM BRT</p>
+            <h1>Physical Computing</h1>
             <p className="description">
-              With Ingrid Dahl, Claire Shorall, Kim Wilkens, and friends.
+              With Jeremy Boggs, Natalie Freed, Andre Garzia, and Jie Qi.
             </p>
           </section>
 
           <p>
-            On our inaugural, International Women’s Day episode, Ingrid Dahl, Claire Shorall, Kim Wilkens and friends prototype teaching and learning materials addressing women’s issues, rights, and accomplishments. Viewers can ask questions and share ideas and prototypes of their own through the embedded agenda and chat.
+            On our April episode of the Mozilla Curriculum Workshop, <LinkAnchorSwap to="http://scholarslab.org/people/jeremy-boggs/">Jeremy Boggs</LinkAnchorSwap>, <LinkAnchorSwap to="http://www.nataliefreed.com/">Natalie Freed</LinkAnchorSwap>, <LinkAnchorSwap to="http://andregarzia.com/pages/en/blog/">Andre Garzia</LinkAnchorSwap>, and <LinkAnchorSwap to="http://technolojie.com/">Jie Qi</LinkAnchorSwap> will help us understand physical computing as a gateway into the Internet of Things (IoT), the network of connected devices embedded in everyday objects. An in-depth episode on IoT will follow this summer. 
           </p>
 
           <p>
-            You can also join the discussion on <a href="https://discourse.webmaker.org/c/mozilla-curriculum-workshop">our community forum</a> or <a href="https://github.com/MozillaFoundation/curriculum-workshop">GitHub</a>.
+            You can also join the discussion on <LinkAnchorSwap to="https://discourse.webmaker.org/c/mozilla-curriculum-workshop">our community forum</LinkAnchorSwap> or <LinkAnchorSwap to="https://github.com/MozillaFoundation/curriculum-workshop">GitHub</LinkAnchorSwap>.
           </p>
 
           <h3>Workshop Video Stream</h3>
 
           <div className="video-wrapper">
-            <iframe className="workshop-video" width="560" height="315" src="//www.youtube.com/embed/WqLgWloYvHk" frameBorder="0" allowFullScreen></iframe>
+            <iframe className="workshop-video" width="560" height="315" src="//www.youtube.com/embed/XjyMkGPP3R0" frameBorder="0" allowFullScreen></iframe>
           </div>
 
           <h4>
             Open Agenda
-            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop">
+            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-april-12-2016">
             </a>
           </h4>
 
-          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop"></iframe>
+          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-april-12-2016"></iframe>
+
+
         </div>
     );
   }

--- a/pages/curriculum-workshop.jsx
+++ b/pages/curriculum-workshop.jsx
@@ -23,20 +23,20 @@ var CurriculumWorkshop = React.createClass({
           </section>
 
           <p>
-          Co-hosts Amira Dhalla and Chad Sansing, along with producer Paul Oh, help participants answer the question, <em>"How can I use the web to teach and learn what’s important to me?"</em> Join us as we prototype teaching and learning materials live on-air and think out-loud through the curriculum design process.
+          Co-hosts Amira Dhalla and Chad Sansing, along with producers Kristina Gorr and Paul Oh, help participants answer the question, <em>"How can I use the web to teach and learn what’s important to me?"</em> Join us as we prototype teaching and learning materials live on-air and think out-loud through the curriculum design process.
           </p>
 
           <section className="callout-box">
             <h2>Upcoming Workshop</h2>
-            <p className="date">April 12th - 5 PM PT, 8 PM ET, 9 PM BRT</p>
-            <h1>Physical Computing</h1>
+            <p className="date">May 10th - 7 AM PT, 10 AM ET, 2 PM GMT</p>
+            <h1>Youth Civic Engagement</h1>
             <p className="description">
-              With Jeremy Boggs, Natalie Freed, Andre Garzia, and Jie Qi
+              With Rafranz Davis, Jeremy Dean, and D.C. Vito
             </p>
           </section>
 
           <p>
-            On our April episode of the Mozilla Curriculum Workshop, <LinkAnchorSwap to="http://scholarslab.org/people/jeremy-boggs/">Jeremy Boggs</LinkAnchorSwap>, <LinkAnchorSwap to="http://www.nataliefreed.com">Natalie Freed</LinkAnchorSwap>, <LinkAnchorSwap to="http://andregarzia.com/pages/en/blog/">Andre Garzia</LinkAnchorSwap>, and <LinkAnchorSwap to="http://technolojie.com/">Jie Qi</LinkAnchorSwap> will help us understand physical computing as a gateway into the Internet of Things (IoT), the network of connected devices embedded in everyday objects. An in-depth episode on IoT will follow this summer. Viewers can add to the discussion and help us prototype web-native teaching and learning materials about physical computing by participating in our etherpad and chat.
+            On our May episode of the Mozilla Curriculum Workshop, Rafranz Davis, Jeremy Dean, and D.C. Vito will help us learn about youth civic engagement. We’ll talk about compelling examples of youth organization and leadership before we prototype resources that might help foster both. Join the work on our shared etherpad and help us build something useful to youth near you!
           </p>
 
           <p>
@@ -46,25 +46,24 @@ var CurriculumWorkshop = React.createClass({
           <h3>Workshop Video Stream</h3>
 
           <div className="video-wrapper">
-            <iframe width="560" height="315" src="//www.youtube.com/embed/XjyMkGPP3R0" frameborder="0" allowfullscreen></iframe>
+            <iframe width="560" height="315" src="//www.youtube.com/embed/dReBsw0oiy0" frameborder="0" allowfullscreen></iframe>
           </div>
-
           <h4>
             Open Agenda
-            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-april-12-2016">
+            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-may-10-2016">
             </a>
           </h4>
 
-          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-april-12-2016"></iframe>
+          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-may-10-2016"></iframe>
 
           <h2>Upcoming Workshops</h2>
 
           <ul className="upcoming-workshops">
             <li>
-              <p className="date">Tuesday, May 10 -  5 PM PT, 8 PM ET, 9 PM BRT</p>
-              <h2>Letters to the Next President</h2>
+              <p className="date">June 14, 2016 - 10am PT / 1pm ET / 5pm GMT</p>
+              <h2>Summer Learning</h2>
               <p>
-                Take a look at the National Writing Project’s Letters to the Next President (#2nextprez) campaign, remix suggested activities from campaign partners Hypothes.is and Mozilla, and prototype new pathways for youth civic engagement online.
+                Join co-hosts Amira Dhalla and Chad Sansing broadcasting live from Mozilla's all-hands work week. Invited guests and drop-in Mozillians will talk shop about summer learning and curriculum development for the web.
               </p>
             </li>
           </ul>
@@ -80,6 +79,16 @@ var CurriculumWorkshop = React.createClass({
               </p>
               <p className="watch-archive">
                 <LinkAnchorSwap to="/community/curriculum-workshop/march-8-2016/">Watch the Replay</LinkAnchorSwap>
+              </p>
+            </li>
+            <li>
+              <p className="date">April 12th, 2016</p>
+              <h2>Physical Computing</h2>
+              <p>
+                On our April episode of the Mozilla Curriculum Workshop, <LinkAnchorSwap to="http://scholarslab.org/people/jeremy-boggs/">Jeremy Boggs</LinkAnchorSwap>, <LinkAnchorSwap to="http://www.nataliefreed.com/">Natalie Freed</LinkAnchorSwap>, <LinkAnchorSwap to="http://andregarzia.com/pages/en/blog/">Andre Garzia</LinkAnchorSwap>, and <LinkAnchorSwap to="http://technolojie.com/">Jie Qi</LinkAnchorSwap> will help us understand physical computing as a gateway into the Internet of Things (IoT), the network of connected devices embedded in everyday objects. An in-depth episode on IoT will follow this summer.
+              </p>
+              <p className="watch-archive">
+                <LinkAnchorSwap to="/community/curriculum-workshop/april-12-2016/">Watch the Replay</LinkAnchorSwap>
               </p>
             </li>
           </ul>


### PR DESCRIPTION
Fixes #1838 

**Changes proposed in this pull request:**
- adds May workshop details to landing page
- adds archive page for April workshop
- updates "upcoming workshops" section of March archive page

cc @flukeout  - R?


